### PR TITLE
Third party libraries updated

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -14,7 +14,7 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="MinVer" Version="4.2.0" PrivateAssets="All" />
+    <PackageReference Include="MinVer" Version="4.3.0" PrivateAssets="All" />
   </ItemGroup>
   
 </Project>

--- a/src/OneBeyond.Studio.FileStorage.Azure/OneBeyond.Studio.FileStorage.Azure.csproj
+++ b/src/OneBeyond.Studio.FileStorage.Azure/OneBeyond.Studio.FileStorage.Azure.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.14.1" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.16.0" />
     <PackageReference Include="Nito.AsyncEx.Coordination" Version="5.1.2" />
   </ItemGroup>
 

--- a/src/OneBeyond.Studio.FileStorage.ConsoleApp/OneBeyond.Studio.FileStorage.ConsoleApp.csproj
+++ b/src/OneBeyond.Studio.FileStorage.ConsoleApp/OneBeyond.Studio.FileStorage.ConsoleApp.csproj
@@ -13,11 +13,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.0">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
   </ItemGroup>
 

--- a/src/OneBeyond.Studio.FileStorage.Domain.Tests/OneBeyond.Studio.FileStorage.Domain.Tests.csproj
+++ b/src/OneBeyond.Studio.FileStorage.Domain.Tests/OneBeyond.Studio.FileStorage.Domain.Tests.csproj
@@ -9,11 +9,11 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
     <PackageReference Include="coverlet.collector" Version="3.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/OneBeyond.Studio.FileStorage.Domain/OneBeyond.Studio.FileStorage.Domain.csproj
+++ b/src/OneBeyond.Studio.FileStorage.Domain/OneBeyond.Studio.FileStorage.Domain.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="10.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
-    <PackageReference Include="morelinq" Version="3.3.2" />
+    <PackageReference Include="morelinq" Version="3.4.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 

--- a/src/OneBeyond.Studio.FileStorage.Domain/OneBeyond.Studio.FileStorage.Domain.csproj
+++ b/src/OneBeyond.Studio.FileStorage.Domain/OneBeyond.Studio.FileStorage.Domain.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Ensure.That" Version="10.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
     <PackageReference Include="morelinq" Version="3.3.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Third party libraries updated:

Azure.Storage.Blobs: 12.14.1 -> 12.16.0
Microsoft.EntityFrameworkCore.Tools: 7.0.0 -> 7.0.5
Microsoft.Extensions.Configuration.Binder: 7.0.0 -> 7.0.4
Microsoft.NET.Test.Sdk: 17.4.0 -> 17.5.0
MinVer: 4.2.0 -> 4.3.0
morelinq: 3.3.2 -> 3.4.2
MSTest.TestAdapter: 3.0.0 -> 3.0.2
MSTest.TestFramework: 3.0.0 -> 3.0.2
Newtonsoft.Json: 13.0.2 -> 13.0.3

No breaking changes.